### PR TITLE
Support for version 0.10.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.idea
 
 # Spyder project settings
 .spyderproject

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 2.7 (rasa)" project-jdk-type="Python SDK" />
-</project>

--- a/rasa_addons/superagent/__init__.py
+++ b/rasa_addons/superagent/__init__.py
@@ -21,10 +21,10 @@ class SuperAgent(Agent):
         self.create_dispatcher = create_dispatcher
         self.rules_file = rules_file
         super(SuperAgent, self).__init__(
-            domain,
-            policies,
-            interpreter,
-            tracker_store
+            domain=domain,
+            policies=policies,
+            interpreter=interpreter,
+            tracker_store=tracker_store
         )
 
     @classmethod
@@ -46,7 +46,14 @@ class SuperAgent(Agent):
         ensemble = PolicyEnsemble.load(path)
         _interpreter = NaturalLanguageInterpreter.create(interpreter)
         _tracker_store = cls.create_tracker_store(tracker_store, domain)
-        return cls(domain, ensemble, _interpreter, _tracker_store, rules_file=rules_file, create_dispatcher=create_dispatcher)
+        return cls(
+                domain=domain,
+                policies=ensemble,
+                interpreter=_interpreter,
+                tracker_store=_tracker_store,
+                rules_file=rules_file,
+                create_dispatcher=create_dispatcher
+        )
 
     def _create_processor(self, preprocessor=None):
         # type: (Callable[[Text], Text]) -> MessageProcessor

--- a/rasa_addons/superagent/__init__.py
+++ b/rasa_addons/superagent/__init__.py
@@ -66,5 +66,6 @@ class SuperAgent(Agent):
                                                self.tracker_store,
                                                create_dispatcher=self.create_dispatcher,
                                                message_preprocessor=preprocessor,
+                                               generator=self.nlg,
                                                rules_file=self.rules_file)
         return self.processor


### PR DESCRIPTION
A new parameter has been added to rasa core Agent `__init__` function, `generator`.
It has been added right before the old tracker_store argument, so it breaks when rasa-addons sends the tracker as a generator to the base Agent class. Specifying the arguments from rasa-addons when creating the base class fixes the issue.

We might want to create a generator ourselves and send it to the base class, but Im leaving that to someone who knows more about the generators. 