### PR TITLE
add fallback rule (issue #6)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,7 +62,7 @@ Rules are enforced at the tracker level, so there is no need to retrain when cha
 
 ## Disambiguate user input and fallback
 
-### Disambiguation
+### Disambiguation policy
 
 Help your users when your NLU struggles to identify the right intent. Instead of just going with the highest scoring intent
 you can ask the user to pick from a list of likely intents. 
@@ -79,21 +79,19 @@ The bot will utter:
  
 ```yaml
 disambiguation_policy:
-  nlu:
-    disambiguation:
-      trigger: $0 < 2 * $1
-      max_suggestions: 2
-      display:
-        intro_template: utter_disamb_intro
-        text_template: utter_disamb_text
-        button_title_template_prefix: utter_disamb
-        fallback_button:
-          title: utter_fallback
-          payload: /fallback
+  trigger: $0 < 2 * $1
+  max_suggestions: 2
+  display:
+    intro_template: utter_disamb_intro
+    text_template: utter_disamb_text
+    button_title_template_prefix: utter_disamb
+    fallback_button:
+      title: utter_fallback_yes
+      payload: /fallback
 ```
-Note about the trigger. `$0` corresponds to `parse_data['intent_ranking'][0]["confidence"]`. You can set any rule based on intent ranking
+Note about the trigger: `$0` corresponds to `parse_data['intent_ranking'][0]["confidence"]`. You can set any rule based on intent ranking
 
-### Fallback
+### Fallback policy
 
 You may want to make the bot go straight to suggesting fallback (e.g when the top intent ranking is low).
 
@@ -104,37 +102,34 @@ The bot will utter:
 2. Optional buttons (if `buttons` list with at least one item - a pair of `title` and `payload` - is defined).
 
 ```yaml
-disambiguation_policy:
-  nlu:
-    fallback:
-      trigger: $0 < 0.5
-      display:
-        text: utter_fallback_intro
-        buttons:
-          - title: utter_fallback_yes
-            payload: /fallback
-          - title: utter_fallback_no
-            payload: /restart
+fallback_policy:
+  trigger: $0 < 0.5
+  display:
+    text: utter_fallback_intro
+    buttons:
+      - title: utter_fallback_yes
+        payload: /fallback
+      - title: utter_fallback_no
+        payload: /restart
 ```
 
 There is no limit on the number of buttons you can define for fallback. If no buttons are defined, this
-rule will simply make the bot utter some default message (e.g `utter_fallback_intro`) when the top intent confidence is lower than the trigger.
+policy will simply make the bot utter some default message (e.g `utter_fallback_intro`) when the top intent confidence is lower than the trigger.
 
 
-### Using both disambiguation and fallback
+### Using both disambiguation and fallback policies
 
-It's easy to use both disambiguation and fallback rules in the same policy. It can be done by filling in rule definitions from two previous examples as follows:
+It's easy to combine both disambiguation and fallback policies. It can be done by filling in policy definitions from two previous examples as follows:
 
 ```yaml
 disambiguation_policy:
-  nlu:
-    disambiguation:
-      (...disambiguation definition...)
-    fallback:
-      (...fallback definition...)
+      (...disambiguation policy definition...)
+
+fallback_policy:
+      (...fallback policy definition...)
 ```
 
-In cases when intent confidence scores in parsed data are such that would cause both rules to trigger, only fallback rule is trigerred. In other words, **fallback rule has precedence over disambiguation rule**.
+In cases when intent confidence scores in parsed data are such that would cause both policies to trigger, only fallback policy is trigerred. In other words, **fallback policy has precedence over disambiguation policy**.
 
 ## Swap intents
 Some intents are hard to catch. For example when the user is asked to fill arbitrary data such as a date or a proper noun. 

--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,8 @@ Rules are enforced at the tracker level, so there is no need to retrain when cha
 
 ## Disambiguate user input and fallback
 
+### Disambiguation
+
 Help your users when your NLU struggles to identify the right intent. Instead of just going with the highest scoring intent
 you can ask the user to pick from a list of likely intents. 
 
@@ -73,23 +75,66 @@ The bot will utter:
  - the text is the template defined as `text_template`, 
  - the button titles will be the concatenation of "utter_disamb" and the intent name. For example, `utter_disamb_greet`."   
  - the buttons payloads will be the corresponding intents (e.g. `/greet`). Entities found in `parse_data` are passed on.
+3. A fallback button to go along with disambiguation buttons (if the optional field `fallback_button` is present)  
  
 ```yaml
 disambiguation_policy:
   nlu:
-    trigger: $0 < 2 * $1
-    display:
-      type: text_with_buttons
-      intro_template: utter_disamb_intro
-      text_template: utter_disamb_text
-      button_title_template_prefix: utter_disamb
-      fallback_title: utter_fallback
-      fallback_payload: /fallback
+    disambiguation:
+      trigger: $0 < 2 * $1
       max_suggestions: 2
+      display:
+        intro_template: utter_disamb_intro
+        text_template: utter_disamb_text
+        button_title_template_prefix: utter_disamb
+        fallback_button:
+          title: utter_fallback
+          payload: /fallback
 ```
-Note about the trigger. `$0` corresponds to `parse_data['intent_ranking][0]["confidence"]`. You can set any rule based on intent ranking
+Note about the trigger. `$0` corresponds to `parse_data['intent_ranking'][0]["confidence"]`. You can set any rule based on intent ranking
+
+### Fallback
+
+You may want to make the bot go straight to suggesting fallback (e.g when the top intent ranking is low).
+
+In the example below, fallback is triggered when the top scoring intent's confidence is below 0.5.
+
+The bot will utter:
+1. An intro message `utter_fallback_intro`
+2. Optional buttons (if `buttons` list with at least one item - a pair of `title` and `payload` - is defined).
+
+```yaml
+disambiguation_policy:
+  nlu:
+    fallback:
+      trigger: $0 < 0.5
+      display:
+        text: utter_fallback_intro
+        buttons:
+          - title: utter_fallback_yes
+            payload: /fallback
+          - title: utter_fallback_no
+            payload: /restart
+```
+
+There is no limit on the number of buttons you can define for fallback. If no buttons are defined, this
+rule will simply make the bot utter some default message (e.g `utter_fallback_intro`) when the top intent confidence is lower than the trigger.
 
 
+### Using both disambiguation and fallback
+
+It's easy to use both disambiguation and fallback rules in the same policy. It can be done by filling in rule definitions from two previous examples as follows:
+
+```yaml
+disambiguation_policy:
+  nlu:
+    disambiguation:
+      (...disambiguation definition...)
+    fallback:
+      (...fallback definition...)
+```
+
+In cases when intent confidence scores in parsed data are such that would cause both rules to trigger, only fallback rule is trigerred. In other words, **fallback rule has precedence over disambiguation rule**.
 
 ## Swap intents
 Some intents are hard to catch. For example when the user is asked to fill arbitrary data such as a date or a proper noun. 

--- a/rasa_addons/superagent/dismabiguator.py
+++ b/rasa_addons/superagent/dismabiguator.py
@@ -6,45 +6,71 @@ from rasa_core.events import Restarted
 
 
 class Disambiguator(object):
-    def __init__(self, rule):
-        self.rule = rule["nlu"] if "nlu" in rule else {}
+    def __init__(self, rules):
+        rules = rules["nlu"] if "nlu" in rules else {}
 
-        self.schema = Schema({"trigger": And(str, len),
-                              "display": {
-                                  'type': And(str, lambda t: t in ["text_with_buttons"], error="type must be text_with_buttons"),
-                                  Optional("intro_template"):  And(str, len),
-                                  "text_template":  And(str, len, error="text_template is required"),
-                                  Optional("button_title_template_prefix", default="utter_disamb"): And(str, len),
-                                  Optional("fallback_title"): And(str, len, error="fallback_title is required"),
-                                  Optional("fallback_payload"): And(str, len, error="fallback_payload is required"),
-                                  Optional("max_suggestions", default=2): int}
-                              })
+        self.schema = Schema({Optional("disambiguation"): {
+                                "trigger": And(str, len),
+                                Optional("max_suggestions", default=2): int,
+                                "display": {
+                                    Optional("intro_template"): And(str, len),
+                                    "text_template": And(str, len, error="text_template is required"),
+                                    Optional("button_title_template_prefix", default="utter_disamb"): And(str, len),
+                                    Optional("fallback_button"): {
+                                        "title": And(str, len, error="fallback button title is required"),
+                                        "payload": And(str, len, error="fallback button payload is required")
+                                    }
+                                }   
+                            },
+                            Optional("fallback"): {
+                                "trigger": And(str, len),
+                                "display": {
+                                    "text": And(str, len),
+                                    Optional("buttons"): 
+                                        [{"title": And(str, len, error="button title is required"), 
+                                        "payload": And(str, len, error="button title is required")}]
+                                    }
+                                }
+                            })
 
-        self.schema.validate(self.rule)
+        self.schema.validate(rules)
 
-        if "max_suggestion" not in self.rule["display"]:
-            self.rule["display"]["max_suggestions"] = 2
+        self.disamb_rule = rules.get("disambiguation", None)
+        self.fallback_rule = rules.get("fallback", None)
 
-        if "button_title_template_prefix" not in self.rule["display"]:
-            self.rule["display"]["button_title_template_prefix"] = "utter_disamb"
+        if self.disamb_rule and "max_suggestion" not in self.disamb_rule:
+            self.disamb_rule["max_suggestions"] = 2
 
-    def should_disambiguate(self, parse_data):
-        if "intent_ranking" not in parse_data:
-            return False
+        if self.disamb_rule and "button_title_template_prefix" not in self.disamb_rule["display"]:
+            self.disamb_rule["display"]["button_title_template_prefix"] = "utter_disamb"
 
+    @staticmethod
+    def is_triggered(parse_data, trigger):
         pattern = re.compile(r"\$(\d)")
-        eval_string = self.rule["trigger"]
-        matches = re.findall(pattern, self.rule["trigger"])
+        eval_string = trigger
+        matches = re.findall(pattern, trigger)
         for i in matches:
-            # if not enough intents in ranking to apply the rule, no disambiguation can be done
+            # if not enough intents in ranking to apply the rule, no fallback can be done
             if int(i) >= len(parse_data["intent_ranking"]):
                 return False
             eval_string = re.sub(r'\$' + i, str(parse_data["intent_ranking"][int(i)]["confidence"]), eval_string)
 
         return len(parse_data["intent_ranking"]) and eval(eval_string, {'__builtins__': {}})
 
+    def should_fallback(self, parse_data):
+        if not self.fallback_rule or "intent_ranking" not in parse_data:
+            return False
+
+        return self.is_triggered(parse_data, self.fallback_rule["trigger"])
+
+    def should_disambiguate(self, parse_data):
+        if not self.disamb_rule or "intent_ranking" not in parse_data:
+            return False
+
+        return self.is_triggered(parse_data, self.disamb_rule["trigger"])
+
     def get_payloads(self, parse_data, keep_entities=True):
-        intents = list(map(lambda x: x["name"], parse_data["intent_ranking"]))[:self.rule["display"]["max_suggestions"]]
+        intents = list(map(lambda x: x["name"], parse_data["intent_ranking"]))[:self.disamb_rule["max_suggestions"]]
         entities = ""
         if "entities" in parse_data and keep_entities:
             entities = json.dumps(dict(map(lambda e: (e["entity"], e["value"]), parse_data["entities"])))
@@ -52,16 +78,23 @@ class Disambiguator(object):
         return payloads
 
     def get_intent_names(self, parse_data):
-        return list(map(lambda x: x["name"], parse_data["intent_ranking"]))[:self.rule["display"]["max_suggestions"]]
+        return list(map(lambda x: x["name"], parse_data["intent_ranking"]))[:self.disamb_rule["max_suggestions"]]
 
     def disambiguate(self, parse_data, tracker, dispatcher, run_action):
         should_disambiguate = self.should_disambiguate(parse_data)
 
         if should_disambiguate:
-            action = ActionDisambiguate(self.rule, self.get_payloads(parse_data), self.get_intent_names(parse_data))
+            action = ActionDisambiguate(self.disamb_rule, self.get_payloads(parse_data), self.get_intent_names(parse_data))
             run_action(action, tracker, dispatcher)
             return True
 
+    def fallback(self, parse_data, tracker, dispatcher, run_action):
+        should_fallback = self.should_fallback(parse_data)
+
+        if should_fallback:
+            action = ActionFallback(self.fallback_rule)
+            run_action(action, tracker, dispatcher)
+            return True
 
 class ActionDisambiguate(Action):
 
@@ -77,10 +110,12 @@ class ActionDisambiguate(Action):
                 "{}_{}".format(rule["display"]["button_title_template_prefix"], i[0]))[
                 "text"], "payload": i[1]} for i in zip(intents, payloads)])
 
-        if "fallback_title" in rule["display"] and "fallback_payload" in rule["display"]:
+        if "fallback_button" in rule["display"] and \
+            "title" in rule["display"]["fallback_button"] and \
+            "payload" in rule["display"]["fallback_button"]:
             buttons.append(
-                {"title": dispatcher.retrieve_template(rule["display"]["fallback_title"])["text"],
-                 "payload": rule["display"]["fallback_payload"]
+                {"title": dispatcher.retrieve_template(rule["display"]["fallback_button"]["title"])["text"],
+                 "payload": rule["display"]["fallback_button"]["payload"]
                  })
 
         disambiguation_message = {
@@ -101,3 +136,30 @@ class ActionDisambiguate(Action):
 
     def name(self):
         return 'action_disambiguate'
+
+class ActionFallback(Action):
+
+    def __init__(self, rule):
+        self.rule = rule
+
+    @staticmethod
+    def get_fallback_message(dispatcher, rule):
+        fallback_message = {
+            "text": dispatcher.retrieve_template(rule["display"]["text"])["text"]
+        }
+        if "buttons" in rule["display"]:
+            buttons = list(
+                [{"title": dispatcher.retrieve_template(button["title"])["text"], 
+                "payload": button["payload"]} for button in rule["display"]["buttons"]])
+            fallback_message["buttons"] = buttons
+        return fallback_message
+
+    def run(self, dispatcher, tracker, domain):
+
+        fallback_message = self.get_fallback_message(dispatcher, self.rule)
+
+        dispatcher.utter_response(fallback_message)
+        return [Restarted()]
+
+    def name(self):
+        return 'action_fallback'

--- a/rasa_addons/superagent/message_processor.py
+++ b/rasa_addons/superagent/message_processor.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from rasa_addons.superagent.dismabiguator import ActionDisambiguate
+from rasa_addons.superagent.disambiguator import ActionDisambiguate
 from rasa_addons.superagent.rules import Rules
 from rasa_core.events import UserUttered
 from rasa_core.processor import MessageProcessor

--- a/rasa_addons/superagent/rules.py
+++ b/rasa_addons/superagent/rules.py
@@ -6,7 +6,7 @@ import logging
 import copy
 from rasa_core.events import ActionExecuted
 
-from rasa_addons.superagent.dismabiguator import Disambiguator
+from rasa_addons.superagent.disambiguator import Disambiguator
 from rasa_addons.superagent.input_validator import InputValidator
 
 from rasa_addons.superagent.input_validator import ActionInvalidUtterance
@@ -20,7 +20,8 @@ class Rules(object):
         self.allowed_entities = data["allowed_entities"] if data and "allowed_entities" in data else {}
         self.intent_substitutions = data["intent_substitutions"] if data and "intent_substitutions" in data else []
         self.input_validation = InputValidator(data["input_validation"]) if data and "input_validation" in data else []
-        self.disambiguation_policy = Disambiguator(data["disambiguation_policy"]) if data and "disambiguation_policy" in data else []
+        self.disambiguation_policy = Disambiguator(data.get("disambiguation_policy", None) if data else None, 
+                                                   data.get("fallback_policy", None) if data else None)
 
     def interrupts(self, dispatcher, parse_data, tracker, run_action):
 

--- a/rasa_addons/superagent/rules.py
+++ b/rasa_addons/superagent/rules.py
@@ -26,7 +26,9 @@ class Rules(object):
 
         self.run_swap_intent_rules(parse_data, tracker)
 
-        if self.disambiguation_policy.disambiguate(parse_data, tracker, dispatcher, run_action):
+        # fallback has precedence
+        if self.disambiguation_policy.fallback(parse_data, tracker, dispatcher, run_action) or \
+        self.disambiguation_policy.disambiguate(parse_data, tracker, dispatcher, run_action):
             return True
 
         self.filter_entities(parse_data)

--- a/tests/disambiguator/test_disambiguator2.yaml
+++ b/tests/disambiguator/test_disambiguator2.yaml
@@ -1,12 +1,10 @@
 disambiguation_policy:
-  nlu:
-    disambiguation:
-      trigger: $0 < 2 * $1
-      max_suggestions: 2
-      display:
-        intro_template: utter_disamb_intro
-        text_template: utter_disamb_text
-        button_title_template_prefix: utter_disamb
-        fallback_button:
-          title: utter_fallback
-          payload: /fallback
+  trigger: $0 < 2 * $1
+  max_suggestions: 2
+  display:
+    intro_template: utter_disamb_intro
+    text_template: utter_disamb_text
+    button_title_template_prefix: utter_disamb
+    fallback_button:
+      title: utter_fallback
+      payload: /fallback

--- a/tests/disambiguator/test_disambiguator3.yaml
+++ b/tests/disambiguator/test_disambiguator3.yaml
@@ -1,4 +1,2 @@
 disambiguation_policy:
-  nlu:
-    disambiguation:
-      trigger: $0 < 2 * $1
+  trigger: $0 < 2 * $1

--- a/tests/disambiguator/test_disambiguator4.yaml
+++ b/tests/disambiguator/test_disambiguator4.yaml
@@ -1,10 +1,9 @@
 disambiguation_policy:
   nlu:
-    trigger: $0 < 2 * $1
-    display:
-      type: text_with_buttons
-      intro_template: utter_disamb_intro
-      text_template: utter_disamb_text
-      button_title_template_prefix: utter_disamb
+    disambiguation:
+      trigger: $0 < 2 * $1
       max_suggestions: 2
-
+      display:
+        intro_template: utter_disamb_intro
+        text_template: utter_disamb_text
+        button_title_template_prefix: utter_disamb

--- a/tests/disambiguator/test_disambiguator4.yaml
+++ b/tests/disambiguator/test_disambiguator4.yaml
@@ -1,9 +1,7 @@
 disambiguation_policy:
-  nlu:
-    disambiguation:
-      trigger: $0 < 2 * $1
-      max_suggestions: 2
-      display:
-        intro_template: utter_disamb_intro
-        text_template: utter_disamb_text
-        button_title_template_prefix: utter_disamb
+  trigger: $0 < 2 * $1
+  max_suggestions: 2
+  display:
+    intro_template: utter_disamb_intro
+    text_template: utter_disamb_text
+    button_title_template_prefix: utter_disamb

--- a/tests/disambiguator/test_disambiguator5.yaml
+++ b/tests/disambiguator/test_disambiguator5.yaml
@@ -1,4 +1,2 @@
-disambiguation_policy:
-  nlu:
-    fallback:
-      trigger: $0 < 0.25
+fallback_policy:
+  trigger: $0 < 0.25

--- a/tests/disambiguator/test_disambiguator5.yaml
+++ b/tests/disambiguator/test_disambiguator5.yaml
@@ -1,0 +1,4 @@
+disambiguation_policy:
+  nlu:
+    fallback:
+      trigger: $0 < 0.25

--- a/tests/disambiguator/test_disambiguator6.yaml
+++ b/tests/disambiguator/test_disambiguator6.yaml
@@ -1,0 +1,11 @@
+disambiguation_policy:
+  nlu:
+    fallback:
+      trigger: $0 < 0.5
+      display:
+        text: utter_fallback_intro
+        buttons:
+          - title: utter_fallback_yes
+            payload: /fallback
+          - title: utter_fallback_no
+            payload: /restart

--- a/tests/disambiguator/test_disambiguator6.yaml
+++ b/tests/disambiguator/test_disambiguator6.yaml
@@ -1,11 +1,9 @@
-disambiguation_policy:
-  nlu:
-    fallback:
-      trigger: $0 < 0.5
-      display:
-        text: utter_fallback_intro
-        buttons:
-          - title: utter_fallback_yes
-            payload: /fallback
-          - title: utter_fallback_no
-            payload: /restart
+fallback_policy:
+  trigger: $0 < 0.5
+  display:
+    text: utter_fallback_intro
+    buttons:
+      - title: utter_fallback_yes
+        payload: /fallback
+      - title: utter_fallback_no
+        payload: /restart

--- a/tests/disambiguator/test_disambiguator7.yaml
+++ b/tests/disambiguator/test_disambiguator7.yaml
@@ -1,6 +1,4 @@
-disambiguation_policy:
-  nlu:
-    fallback:
-      trigger: $0 < 0.5
-      display:
-        text: utter_fallback_intro
+fallback_policy:
+  trigger: $0 < 0.5
+  display:
+    text: utter_fallback_intro

--- a/tests/disambiguator/test_disambiguator7.yaml
+++ b/tests/disambiguator/test_disambiguator7.yaml
@@ -1,0 +1,6 @@
+disambiguation_policy:
+  nlu:
+    fallback:
+      trigger: $0 < 0.5
+      display:
+        text: utter_fallback_intro

--- a/tests/disambiguator/test_disambiguator8.yaml
+++ b/tests/disambiguator/test_disambiguator8.yaml
@@ -2,3 +2,6 @@ disambiguation_policy:
   nlu:
     disambiguation:
       trigger: $0 < 2 * $1
+      max_suggestions: 2
+    fallback:
+      trigger: $0 < 0.5

--- a/tests/disambiguator/test_disambiguator8.yaml
+++ b/tests/disambiguator/test_disambiguator8.yaml
@@ -1,7 +1,5 @@
 disambiguation_policy:
-  nlu:
-    disambiguation:
-      trigger: $0 < 2 * $1
-      max_suggestions: 2
-    fallback:
-      trigger: $0 < 0.5
+  trigger: $0 < 2 * $1
+  max_suggestions: 2
+fallback_policy:
+  trigger: $0 < 0.5 

--- a/tests/disambiguator/test_disambiguator9.yaml
+++ b/tests/disambiguator/test_disambiguator9.yaml
@@ -1,21 +1,19 @@
 disambiguation_policy:
-  nlu:
-    disambiguation:
-      trigger: $0 < 2 * $1
-      max_suggestions: 2
-      display:
-        intro_template: utter_disamb_intro
-        text_template: utter_disamb_text
-        button_title_template_prefix: utter_disamb
-        fallback_button:
-          title: utter_fallback
-          payload: /fallback
-    fallback:
-      trigger: $0 < 0.5
-      display:
-        text: utter_fallback_intro
-        buttons:
-          - title: utter_fallback_yes
-            payload: /fallback
-          - title: utter_fallback_no
-            payload: /restart
+  trigger: $0 < 2 * $1
+  max_suggestions: 2
+  display:
+    intro_template: utter_disamb_intro
+    text_template: utter_disamb_text
+    button_title_template_prefix: utter_disamb
+    fallback_button:
+      title: utter_fallback
+      payload: /fallback
+fallback_policy:
+  trigger: $0 < 0.5
+  display:
+    text: utter_fallback_intro
+    buttons:
+      - title: utter_fallback_yes
+        payload: /fallback
+      - title: utter_fallback_no
+        payload: /restart

--- a/tests/disambiguator/test_disambiguator9.yaml
+++ b/tests/disambiguator/test_disambiguator9.yaml
@@ -10,3 +10,12 @@ disambiguation_policy:
         fallback_button:
           title: utter_fallback
           payload: /fallback
+    fallback:
+      trigger: $0 < 0.5
+      display:
+        text: utter_fallback_intro
+        buttons:
+          - title: utter_fallback_yes
+            payload: /fallback
+          - title: utter_fallback_no
+            payload: /restart


### PR DESCRIPTION
### Fallback rule implementation for disambiguation policy ([issue 6](https://github.com/mrbot-ai/rasa-addons/issues/6))

I implemented both `fallback` and `disambiguation` rules as optional. If both rules are defined, `fallback` has precedence.

Also provided test coverage for the new rule similar to the existing tests for `disambiguation`. Other details are in updated readme.

This change is incompatible with existing rules yaml files since the disambiguation policy schema was changed.